### PR TITLE
Add ToaruOS to Unix-like

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Solaris® was originally a UNIX operating system developed jointly by Sun Micros
 * [Akaros](https://github.com/brho/akaros) - Akaros is an open source, GPL-licensed operating system for manycore architectures. The goal is to provide support for parallel and high-performance applications and to scale to a large number of cores. ![Open Source][OSS Icon]
 * [Sortix](https://sortix.org) - Sortix is a small self-hosting operating-system aiming to be a clean and modern POSIX implementation, a hobbyist operating system written from scratch with its own base system, including kernel and standard library, as well as ports of third party software.
 * [OpenVMS](http://www.vmssoftware.com)™ - OpenVMS is a enterprise operating system known for it's reliability. It is the successor to the VMS Operating System and runs on DEC Alpha systems. OpenVMS has it's own software lineage that predates UNIX and [includes Windows NT](http://www.itprotoday.com/windows-client/windows-nt-and-vms-rest-story) but POSIX compatibility was added to OpenVMS in 1991.
+* [ToaruOS](https://github.com/klange/toaruos) - ToaruOS is a hobbyist, educational, Unix-like operating system built entirely from scratch. It includes a kernel, bootloader, dynamic linker, C standard library, composited windowing system, and several utilities and applications. ![Open Source][OSS Icon]
 
 ## Plan 9 Derivatives
 


### PR DESCRIPTION
I hope I'm not being too presumptuous in submitting my own OS, but given that Sortix and Redox are listed, I thought I'd throw ToaruOS in the ring.

In support of ToaruOS's notability for inclusion, [Phoronix](https://distrowatch.com/weekly.php?issue=20170320#toaruos) has had several articles following its development over the years, and [Distrowatch](https://distrowatch.com/weekly.php?issue=20170320#toaruos) had a featured review of its 1.0.4 release. Similar to Sortix, ToaruOS is primarily developed by a single person with a handful of additional contributors. Whereas Sortix's goals are focused on a complete and clean implementation of POSIX, ToaruOS has been focused on user experience and modern functionality and is notable for its composited UI.