### PR TITLE
Add Mocker - Docker-compatible container CLI for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ A [real-time operating system](https://en.wikipedia.org/wiki/Real-time_operating
 - [Awesome Mac](https://github.com/jaywcjlove/awesome-mac)
 - [Awesome macOS Command Line](https://github.com/herrbischoff/awesome-osx-command-line) 
 - [macOS for UNIX Users](http://images.apple.com/media/us/osx/2012/docs/OSX_for_UNIX_Users_TB_July2011.pdf) - Apple Technical Brief, July 2011.
+- [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework. Open source (AGPL-3.0), Swift.
 
 ## More illumos®
 


### PR DESCRIPTION
Adds [Mocker](https://github.com/us/mocker) to the **More macOS** section.

Mocker is a Docker-compatible container CLI for macOS, built on Apple's Containerization framework. It is open source (AGPL-3.0) and written in Swift.